### PR TITLE
Update usage of Akk.actor

### DIFF
--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/Config.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/Config.java
@@ -39,8 +39,8 @@ import com.vmware.thinapp.workpool.model.VmImageModel;
 import com.vmware.thinapp.workpool.model.VmPatternModel;
 import com.vmware.thinapp.workpool.model.WorkpoolModel;
 
-import akka.actor.TypedActor;
-import akka.actor.TypedActorFactory;
+import akka.actor.typed;
+import akka.actor.typedFactory;
 import akka.dispatch.Dispatchers;
 import akka.dispatch.MessageDispatcher;
 

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/InstancerBase.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/InstancerBase.java
@@ -17,7 +17,7 @@
 
 package com.vmware.thinapp.workpool;
 
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import com.google.common.eventbus.EventBus;
 
 /**

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/VCManagerImpl.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/VCManagerImpl.java
@@ -40,7 +40,7 @@ import com.vmware.vim25.mo.InventoryNavigator;
 import com.vmware.vim25.mo.ServiceInstance;
 
 import akka.actor.Scheduler;
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.dispatch.DefaultCompletableFuture;
 import akka.dispatch.Future;
 import akka.dispatch.Futures;

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/VmImageInstanceImpl.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/VmImageInstanceImpl.java
@@ -42,7 +42,7 @@ import com.vmware.vim25.mo.Task;
 import com.vmware.vim25.mo.VirtualMachine;
 import com.vmware.vim25.mo.VirtualMachineSnapshot;
 
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.dispatch.Future;
 import akka.dispatch.Futures;
 import akka.japi.Procedure;

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/VmImageManagerImpl.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/VmImageManagerImpl.java
@@ -35,7 +35,7 @@ import com.vmware.thinapp.common.workpool.dto.DeleteMethod;
 import com.vmware.thinapp.workpool.dao.VmImageRepository;
 import com.vmware.thinapp.workpool.model.VmImageModel;
 
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.dispatch.Future;
 import scala.Option;
 

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/VmInstallerImpl.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/VmInstallerImpl.java
@@ -19,7 +19,7 @@ package com.vmware.thinapp.workpool;
 
 import java.util.concurrent.Callable;
 
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.dispatch.Futures;
 
 public class VmInstallerImpl extends TypedActor implements VmInstaller {

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/WorkpoolInstanceImpl.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/WorkpoolInstanceImpl.java
@@ -49,7 +49,7 @@ import com.vmware.thinapp.workpool.model.LeaseModel;
 import com.vmware.thinapp.workpool.model.WorkpoolModel;
 import com.vmware.vim25.mo.ServiceInstance;
 
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.dispatch.CompletableFuture;
 import akka.dispatch.DefaultCompletableFuture;
 import akka.dispatch.Future;

--- a/workpool-java/src/main/java/com/vmware/thinapp/workpool/WorkpoolManagerImpl.java
+++ b/workpool-java/src/main/java/com/vmware/thinapp/workpool/WorkpoolManagerImpl.java
@@ -42,7 +42,7 @@ import com.vmware.thinapp.workpool.model.VCConfigModel;
 import com.vmware.thinapp.workpool.model.VmLocationModel;
 import com.vmware.thinapp.workpool.model.WorkpoolModel;
 
-import akka.actor.TypedActor;
+import akka.actor.typed;
 import akka.dispatch.Future;
 import scala.Option;
 

--- a/workpool-java/src/test/java/com/vmware/thinapp/workpool/tests/integration/VmImageInstanceTest.scala
+++ b/workpool-java/src/test/java/com/vmware/thinapp/workpool/tests/integration/VmImageInstanceTest.scala
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 import org.springframework.test.context.ContextConfiguration
 import com.vmware.thinapp.workpool.tests.mocks.InstallRunnerMock
-import akka.actor.TypedActor
+import akka.actor.typed
 import org.springframework.beans.factory.annotation.Autowired
 import com.vmware.thinapp.workpool.tests.fixtures.Defaults
 import com.vmware.thinapp.workpool.{Util, VmImageInstance, VmImageInstanceImpl, InstallRequest}


### PR DESCRIPTION
Akka.actor.TypedActor has been deprecated as of 2.6.0 in favor of the akka.actor.typed API which should be used instead.

[_Created by Sourcegraph batch change `christine/update-akka-scala`._](https://demo.sourcegraph.com/users/christine/batch-changes/update-akka-scala)